### PR TITLE
Add deterministic FinanceBench result evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,13 @@ python scripts/evaluate_results.py "results/*.jsonl"
 
 The script reports the human labels included in the result files and a
 deterministic baseline match rate. Gold answers that are pure numeric answers
-are matched against numbers found in the model answer using a configurable
-tolerance, while free-form text answers use exact normalized string matching.
+are matched against an explicit answer span, or an unambiguous one-number model
+answer, using a configurable tolerance; copied filing context blocks are
+ignored. Free-form text answers use exact normalized string matching.
 
 Prediction files from new FinanceBench runs can use the same format as the
 provided result files, or include `answer` plus one of `model_answer`,
-`prediction`, `predicted_answer`, or `response`.
+`final_answer`, `prediction`, `predicted_answer`, or `response`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,27 @@ In addition, we provide the human-annotated model completions of the evaluated m
 
 ---
 
+**Evaluating result files:**
+
+The result files in `/results/` can be summarized with the dependency-free
+evaluation script:
+
+```bash
+python scripts/evaluate_results.py results/gpt-4_closedBook.jsonl
+python scripts/evaluate_results.py "results/*.jsonl"
+```
+
+The script reports the human labels included in the result files and a
+deterministic baseline match rate. Gold answers that are pure numeric answers
+are matched against numbers found in the model answer using a configurable
+tolerance, while free-form text answers use exact normalized string matching.
+
+Prediction files from new FinanceBench runs can use the same format as the
+provided result files, or include `answer` plus one of `model_answer`,
+`prediction`, `predicted_answer`, or `response`.
+
+---
+
 **Citation:** If you use our open-source dataset or refer to our result, please use the following citation:
 ```latex
 @misc{islam2023financebench,

--- a/scripts/evaluate_results.py
+++ b/scripts/evaluate_results.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 
-NUMBER_RE = re.compile(r"\(?[-+]?\$?\d[\d,]*(?:\.\d+)?%?\)?")
+NUMBER_RE = re.compile(r"(?<![A-Za-z_])\(?[-+]?\$?\d[\d,]*(?:\.\d+)?%?\)?(?![A-Za-z_])")
 NUMERIC_ANSWER_RE = re.compile(
     r"^\(?[-+]?\$?\d[\d,]*(?:\.\d+)?%?\)?"
     r"(?:\s*(?:usd|dollars?|millions?|billions?|shares?|bps|basis points))?$",

--- a/scripts/evaluate_results.py
+++ b/scripts/evaluate_results.py
@@ -20,10 +20,18 @@ from pathlib import Path
 from typing import Any, Iterable
 
 
-NUMBER_RE = re.compile(r"(?<![A-Za-z_])\(?[-+]?\$?\d[\d,]*(?:\.\d+)?%?\)?(?![A-Za-z_])")
+UNIT_PATTERN = (
+    r"(?:usd(?:\s+(?:millions?|billions?))?|dollars?|millions?|billions?|"
+    r"shares?|bps|basis points)"
+)
+NUMBER_RE = re.compile(
+    rf"(?<![A-Za-z_])(?P<number>\(?[-+]?\$?\d[\d,]*(?:\.\d+)?%?\)?)(?![A-Za-z_])"
+    rf"(?:\s*(?P<unit>{UNIT_PATTERN}))?",
+    re.IGNORECASE,
+)
 NUMERIC_ANSWER_RE = re.compile(
     r"^\(?[-+]?\$?\d[\d,]*(?:\.\d+)?%?\)?"
-    r"(?:\s*(?:usd|dollars?|millions?|billions?|shares?|bps|basis points))?$",
+    rf"(?:\s*{UNIT_PATTERN})?$",
     re.IGNORECASE,
 )
 FILING_BLOCK_RE = re.compile(
@@ -41,7 +49,7 @@ ANSWER_MARKER_RE = re.compile(
 CALCULATION_RESULT_RE = re.compile(
     r"[^=\n]*(?:[/+*]|\s-\s)[^=\n]*=\s*"
     r"(?P<value>\(?[-+]?\$?\d[\d,]*(?:\.\d+)?%?\)?)"
-    r"(?:\s*(?:usd|dollars?|millions?|billions?|shares?|bps|basis points))?"
+    rf"(?:\s*(?P<unit>{UNIT_PATTERN}))?"
     r"(?=\s*(?:[.,;:]|\n|$))",
     re.IGNORECASE,
 )
@@ -86,7 +94,19 @@ def normalize_text(value: Any) -> str:
     return " ".join(str(value).strip().lower().split())
 
 
-def parse_number_token(token: str) -> float | None:
+def magnitude_multiplier(unit: str | None) -> float:
+    """Return a multiplier that normalizes common money magnitudes to millions."""
+
+    if not unit:
+        return 1.0
+
+    normalized_unit = normalize_text(unit)
+    if "billion" in normalized_unit:
+        return 1000.0
+    return 1.0
+
+
+def parse_number_token(token: str, unit: str | None = None) -> float | None:
     """Parse a currency/percent/parenthesized number token into a float."""
 
     text = token.strip()
@@ -103,6 +123,8 @@ def parse_number_token(token: str) -> float | None:
     if is_percent:
         value /= 100.0
 
+    value *= magnitude_multiplier(unit)
+
     return -value if negative else value
 
 
@@ -117,8 +139,8 @@ def extract_numbers(value: Any) -> list[float]:
         return []
 
     numbers: list[float] = []
-    for token in NUMBER_RE.findall(str(value)):
-        parsed = parse_number_token(token)
+    for match in NUMBER_RE.finditer(str(value)):
+        parsed = parse_number_token(match.group("number"), match.group("unit"))
         if parsed is not None:
             numbers.append(parsed)
     return numbers
@@ -147,7 +169,10 @@ def extract_answer_numbers(value: Any) -> list[float]:
 
     calculation_matches = list(CALCULATION_RESULT_RE.finditer(text))
     if calculation_matches:
-        parsed = parse_number_token(calculation_matches[-1].group("value"))
+        parsed = parse_number_token(
+            calculation_matches[-1].group("value"),
+            calculation_matches[-1].group("unit"),
+        )
         if parsed is not None:
             return [parsed]
 

--- a/scripts/evaluate_results.py
+++ b/scripts/evaluate_results.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Evaluate FinanceBench result JSONL files with deterministic metrics.
+
+The script is intentionally dependency-free so it can run in a fresh checkout.
+It supports the result files already checked into this repository and future
+prediction files that contain a gold answer plus a model answer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import math
+import re
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+NUMBER_RE = re.compile(r"\(?[-+]?\$?\d[\d,]*(?:\.\d+)?%?\)?")
+NUMERIC_ANSWER_RE = re.compile(
+    r"^\(?[-+]?\$?\d[\d,]*(?:\.\d+)?%?\)?"
+    r"(?:\s*(?:usd|dollars?|millions?|billions?|shares?|bps|basis points))?$",
+    re.IGNORECASE,
+)
+REFUSAL_PHRASES = (
+    "as an ai",
+    "cannot provide",
+    "can't provide",
+    "do not have access",
+    "don't have access",
+    "doesn't provide",
+    "does not provide",
+    "i don't have",
+    "i do not have",
+    "no information",
+    "not enough information",
+    "not provided",
+    "recommend checking",
+    "unable to",
+)
+
+
+@dataclass
+class FileSummary:
+    path: Path
+    rows: int
+    deterministic_matches: int
+    deterministic_scored: int
+    labels: Counter[str]
+
+
+def normalize_text(value: Any) -> str:
+    """Return a compact, case-insensitive representation for exact matching."""
+
+    return " ".join(str(value).strip().lower().split())
+
+
+def parse_number_token(token: str) -> float | None:
+    """Parse a currency/percent/parenthesized number token into a float."""
+
+    text = token.strip()
+    negative = text.startswith("(") and text.endswith(")")
+    text = text.strip("()")
+    text = text.replace("$", "").replace(",", "").replace("%", "")
+
+    try:
+        value = float(text)
+    except ValueError:
+        return None
+
+    return -value if negative else value
+
+
+def extract_numbers(value: Any) -> list[float]:
+    """Extract numeric tokens from strings or return numeric values directly."""
+
+    if isinstance(value, bool):
+        return []
+    if isinstance(value, (int, float)):
+        if math.isfinite(float(value)):
+            return [float(value)]
+        return []
+
+    numbers: list[float] = []
+    for token in NUMBER_RE.findall(str(value)):
+        parsed = parse_number_token(token)
+        if parsed is not None:
+            numbers.append(parsed)
+    return numbers
+
+
+def is_numeric_answer(value: Any) -> bool:
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, (int, float)):
+        return math.isfinite(float(value))
+    return bool(NUMERIC_ANSWER_RE.fullmatch(str(value).strip()))
+
+
+def looks_like_refusal(value: Any) -> bool:
+    text = normalize_text(value)
+    return any(phrase in text for phrase in REFUSAL_PHRASES)
+
+
+def numbers_match(
+    expected: float,
+    observed: float,
+    *,
+    relative_tolerance: float,
+    absolute_tolerance: float,
+) -> bool:
+    return math.isclose(
+        observed,
+        expected,
+        rel_tol=relative_tolerance,
+        abs_tol=absolute_tolerance,
+    )
+
+
+def deterministic_match(
+    gold_answer: Any,
+    model_answer: Any,
+    *,
+    relative_tolerance: float,
+    absolute_tolerance: float,
+) -> bool:
+    """Score a response without an LLM judge.
+
+    Numeric gold answers are matched against any number in the model answer.
+    Non-numeric gold answers fall back to exact normalized string equality.
+    This deliberately avoids claiming semantic equivalence for free-form text.
+    """
+
+    if looks_like_refusal(model_answer):
+        return False
+
+    if not is_numeric_answer(gold_answer):
+        return normalize_text(gold_answer) == normalize_text(model_answer)
+
+    expected_numbers = extract_numbers(gold_answer)
+    observed_numbers = extract_numbers(model_answer)
+
+    if expected_numbers:
+        return any(
+            numbers_match(
+                expected,
+                observed,
+                relative_tolerance=relative_tolerance,
+                absolute_tolerance=absolute_tolerance,
+            )
+            for expected in expected_numbers
+            for observed in observed_numbers
+        )
+
+    return False
+
+
+def read_jsonl(path: Path) -> Iterable[dict[str, Any]]:
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{line_number}: invalid JSONL row") from exc
+            if not isinstance(row, dict):
+                raise ValueError(f"{path}:{line_number}: expected a JSON object")
+            yield row
+
+
+def get_gold_answer(row: dict[str, Any]) -> Any:
+    if "gold_answer" in row:
+        return row["gold_answer"]
+    if "answer" in row:
+        return row["answer"]
+    raise KeyError("missing gold_answer or answer")
+
+
+def get_model_answer(row: dict[str, Any]) -> Any:
+    for field in ("model_answer", "prediction", "predicted_answer", "response"):
+        if field in row:
+            return row[field]
+    raise KeyError("missing model_answer, prediction, predicted_answer, or response")
+
+
+def summarize_file(
+    path: Path,
+    *,
+    relative_tolerance: float,
+    absolute_tolerance: float,
+) -> FileSummary:
+    labels: Counter[str] = Counter()
+    rows = 0
+    deterministic_scored = 0
+    deterministic_matches = 0
+
+    for row in read_jsonl(path):
+        rows += 1
+        label = row.get("label")
+        if label is not None:
+            labels[str(label)] += 1
+
+        try:
+            gold_answer = get_gold_answer(row)
+            model_answer = get_model_answer(row)
+        except KeyError:
+            continue
+
+        deterministic_scored += 1
+        if deterministic_match(
+            gold_answer,
+            model_answer,
+            relative_tolerance=relative_tolerance,
+            absolute_tolerance=absolute_tolerance,
+        ):
+            deterministic_matches += 1
+
+    return FileSummary(
+        path=path,
+        rows=rows,
+        deterministic_matches=deterministic_matches,
+        deterministic_scored=deterministic_scored,
+        labels=labels,
+    )
+
+
+def expand_paths(patterns: Iterable[str]) -> list[Path]:
+    paths: list[Path] = []
+    for pattern in patterns:
+        matches = sorted(glob.glob(pattern))
+        if matches:
+            paths.extend(Path(match) for match in matches)
+        else:
+            paths.append(Path(pattern))
+
+    missing = [str(path) for path in paths if not path.exists()]
+    if missing:
+        missing_list = ", ".join(missing)
+        raise FileNotFoundError(f"Input file(s) not found: {missing_list}")
+
+    return paths
+
+
+def percent(numerator: int, denominator: int) -> str:
+    if denominator == 0:
+        return "n/a"
+    return f"{numerator / denominator:.1%}"
+
+
+def render_table(summaries: list[FileSummary]) -> str:
+    headers = [
+        "file",
+        "rows",
+        "human_correct",
+        "human_incorrect",
+        "human_refusal",
+        "deterministic_match",
+    ]
+    rows = []
+    totals: defaultdict[str, int] = defaultdict(int)
+
+    for summary in summaries:
+        human_correct = summary.labels.get("Correct Answer", 0)
+        human_incorrect = summary.labels.get("Incorrect Answer", 0)
+        human_refusal = summary.labels.get("Refusal", 0)
+        rows.append(
+            [
+                str(summary.path),
+                str(summary.rows),
+                percent(human_correct, summary.rows),
+                percent(human_incorrect, summary.rows),
+                percent(human_refusal, summary.rows),
+                percent(summary.deterministic_matches, summary.deterministic_scored),
+            ]
+        )
+        totals["rows"] += summary.rows
+        totals["human_correct"] += human_correct
+        totals["human_incorrect"] += human_incorrect
+        totals["human_refusal"] += human_refusal
+        totals["deterministic_matches"] += summary.deterministic_matches
+        totals["deterministic_scored"] += summary.deterministic_scored
+
+    if len(summaries) > 1:
+        rows.append(
+            [
+                "TOTAL",
+                str(totals["rows"]),
+                percent(totals["human_correct"], totals["rows"]),
+                percent(totals["human_incorrect"], totals["rows"]),
+                percent(totals["human_refusal"], totals["rows"]),
+                percent(
+                    totals["deterministic_matches"],
+                    totals["deterministic_scored"],
+                ),
+            ]
+        )
+
+    widths = [
+        max(len(row[index]) for row in [headers, *rows])
+        for index in range(len(headers))
+    ]
+    lines = [
+        "  ".join(cell.ljust(widths[index]) for index, cell in enumerate(headers)),
+        "  ".join("-" * width for width in widths),
+    ]
+    lines.extend(
+        "  ".join(cell.ljust(widths[index]) for index, cell in enumerate(row))
+        for row in rows
+    )
+    return "\n".join(lines)
+
+
+def render_json(summaries: list[FileSummary]) -> str:
+    payload = []
+    for summary in summaries:
+        payload.append(
+            {
+                "file": str(summary.path),
+                "rows": summary.rows,
+                "labels": dict(summary.labels),
+                "deterministic_matches": summary.deterministic_matches,
+                "deterministic_scored": summary.deterministic_scored,
+                "deterministic_match_rate": (
+                    summary.deterministic_matches / summary.deterministic_scored
+                    if summary.deterministic_scored
+                    else None
+                ),
+            }
+        )
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evaluate FinanceBench result or prediction JSONL files."
+    )
+    parser.add_argument(
+        "inputs",
+        nargs="+",
+        help="JSONL file paths or glob patterns, for example results/*.jsonl.",
+    )
+    parser.add_argument(
+        "--relative-tolerance",
+        type=float,
+        default=0.01,
+        help="Relative tolerance for numeric deterministic matching.",
+    )
+    parser.add_argument(
+        "--absolute-tolerance",
+        type=float,
+        default=1e-6,
+        help="Absolute tolerance for numeric deterministic matching.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("table", "json"),
+        default="table",
+        help="Output format.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    paths = expand_paths(args.inputs)
+    summaries = [
+        summarize_file(
+            path,
+            relative_tolerance=args.relative_tolerance,
+            absolute_tolerance=args.absolute_tolerance,
+        )
+        for path in paths
+    ]
+
+    if args.format == "json":
+        print(render_json(summaries))
+    else:
+        print(render_table(summaries))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/evaluate_results.py
+++ b/scripts/evaluate_results.py
@@ -38,6 +38,13 @@ ANSWER_MARKER_RE = re.compile(
     r"(?:is|was|were|would\s+be|:|=)\s*",
     re.IGNORECASE | re.DOTALL,
 )
+CALCULATION_RESULT_RE = re.compile(
+    r"[^=\n]*(?:[/+*]|\s-\s)[^=\n]*=\s*"
+    r"(?P<value>\(?[-+]?\$?\d[\d,]*(?:\.\d+)?%?\)?)"
+    r"(?:\s*(?:usd|dollars?|millions?|billions?|shares?|bps|basis points))?"
+    r"(?=\s*(?:[.,;:]|\n|$))",
+    re.IGNORECASE,
+)
 REFUSAL_PHRASES = (
     "as an ai",
     "cannot provide",
@@ -137,6 +144,12 @@ def extract_answer_numbers(value: Any) -> list[float]:
     marker_matches = list(ANSWER_MARKER_RE.finditer(text))
     if marker_matches:
         return extract_numbers(text[marker_matches[-1].end() :])[:1]
+
+    calculation_matches = list(CALCULATION_RESULT_RE.finditer(text))
+    if calculation_matches:
+        parsed = parse_number_token(calculation_matches[-1].group("value"))
+        if parsed is not None:
+            return [parsed]
 
     numbers = extract_numbers(CONTEXT_YEAR_RE.sub(" ", text))
     return numbers if len(numbers) <= 1 else []

--- a/scripts/evaluate_results.py
+++ b/scripts/evaluate_results.py
@@ -404,7 +404,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--relative-tolerance",
         type=float,
-        default=0.01,
+        default=0.001,
         help="Relative tolerance for numeric deterministic matching.",
     )
     parser.add_argument(

--- a/scripts/evaluate_results.py
+++ b/scripts/evaluate_results.py
@@ -197,26 +197,47 @@ def deterministic_match(
     This deliberately avoids claiming semantic equivalence for free-form text.
     """
 
-    if looks_like_refusal(model_answer):
-        return False
-
     if not is_numeric_answer(gold_answer):
+        if looks_like_refusal(model_answer):
+            return False
         return normalize_text(gold_answer) == normalize_text(model_answer)
 
     expected_numbers = extract_numbers(gold_answer)
     observed_numbers = extract_answer_numbers(model_answer)
 
     if expected_numbers:
-        return any(
-            numbers_match(
+        matched_pairs = [
+            (expected, observed)
+            for expected in expected_numbers
+            for observed in observed_numbers
+            if numbers_match(
                 expected,
                 observed,
                 relative_tolerance=relative_tolerance,
                 absolute_tolerance=absolute_tolerance,
             )
-            for expected in expected_numbers
-            for observed in observed_numbers
-        )
+        ]
+        if not matched_pairs:
+            return False
+
+        if looks_like_refusal(model_answer):
+            return any(
+                numbers_match(
+                    0.0,
+                    expected,
+                    relative_tolerance=relative_tolerance,
+                    absolute_tolerance=absolute_tolerance,
+                )
+                and numbers_match(
+                    0.0,
+                    observed,
+                    relative_tolerance=relative_tolerance,
+                    absolute_tolerance=absolute_tolerance,
+                )
+                for expected, observed in matched_pairs
+            )
+
+        return True
 
     return False
 

--- a/scripts/evaluate_results.py
+++ b/scripts/evaluate_results.py
@@ -106,6 +106,13 @@ class FileSummary:
     labels: Counter[str]
 
 
+@dataclass(frozen=True)
+class NumberCandidate:
+    value: float
+    is_percent: bool = False
+    unit: str | None = None
+
+
 def normalize_text(value: Any) -> str:
     """Return a compact, case-insensitive representation for exact matching."""
 
@@ -126,6 +133,15 @@ def infer_answer_money_scale(question: Any) -> str:
     return "millions"
 
 
+def expects_money_answer(question: Any, gold_answer: Any) -> bool:
+    text = normalize_text(question)
+    if MONEY_SCALE_RE.search(text) or "usd" in text or "dollar" in text:
+        return True
+
+    gold_text = normalize_text(gold_answer)
+    return "$" in str(gold_answer) or bool(MONEY_SCALE_RE.search(gold_text))
+
+
 def magnitude_multiplier(
     unit: str | None,
     *,
@@ -144,13 +160,13 @@ def magnitude_multiplier(
     return 1.0
 
 
-def parse_number_token(
+def parse_number_candidate(
     token: str,
     unit: str | None = None,
     *,
     answer_money_scale: str = "millions",
-) -> float | None:
-    """Parse a currency/percent/parenthesized number token into a float."""
+) -> NumberCandidate | None:
+    """Parse a currency/percent/parenthesized number token with unit metadata."""
 
     text = token.strip()
     negative = text.startswith("(") and text.endswith(")")
@@ -168,29 +184,68 @@ def parse_number_token(
 
     value *= magnitude_multiplier(unit, answer_money_scale=answer_money_scale)
 
-    return -value if negative else value
+    if negative:
+        value = -value
+
+    return NumberCandidate(
+        value=value,
+        is_percent=is_percent,
+        unit=normalize_text(unit) if unit else None,
+    )
 
 
-def extract_numbers(value: Any, *, answer_money_scale: str = "millions") -> list[float]:
-    """Extract numeric tokens from strings or return numeric values directly."""
+def parse_number_token(
+    token: str,
+    unit: str | None = None,
+    *,
+    answer_money_scale: str = "millions",
+) -> float | None:
+    """Parse a currency/percent/parenthesized number token into a float."""
+
+    candidate = parse_number_candidate(
+        token,
+        unit,
+        answer_money_scale=answer_money_scale,
+    )
+    return candidate.value if candidate else None
+
+
+def extract_number_candidates(
+    value: Any,
+    *,
+    answer_money_scale: str = "millions",
+) -> list[NumberCandidate]:
+    """Extract numeric tokens with unit metadata."""
 
     if isinstance(value, bool):
         return []
     if isinstance(value, (int, float)):
         if math.isfinite(float(value)):
-            return [float(value)]
+            return [NumberCandidate(float(value))]
         return []
 
-    numbers: list[float] = []
+    candidates: list[NumberCandidate] = []
     for match in NUMBER_RE.finditer(str(value)):
-        parsed = parse_number_token(
+        parsed = parse_number_candidate(
             match.group("number"),
             match.group("unit"),
             answer_money_scale=answer_money_scale,
         )
         if parsed is not None:
-            numbers.append(parsed)
-    return numbers
+            candidates.append(parsed)
+    return candidates
+
+
+def extract_numbers(value: Any, *, answer_money_scale: str = "millions") -> list[float]:
+    """Extract numeric tokens from strings or return numeric values directly."""
+
+    return [
+        candidate.value
+        for candidate in extract_number_candidates(
+            value,
+            answer_money_scale=answer_money_scale,
+        )
+    ]
 
 
 def strip_filing_context(value: str) -> str:
@@ -224,15 +279,15 @@ def strip_temporal_context(
     return text
 
 
-def extract_answer_numbers(
+def extract_answer_number_candidates(
     value: Any,
     *,
     answer_money_scale: str = "millions",
-) -> list[float]:
-    """Extract numbers that are likely to be the answer, not copied context."""
+) -> list[NumberCandidate]:
+    """Extract answer-like numeric candidates, not copied context."""
 
     if not isinstance(value, str):
-        return extract_numbers(value, answer_money_scale=answer_money_scale)
+        return extract_number_candidates(value, answer_money_scale=answer_money_scale)
 
     text = strip_filing_context(value)
     if not text:
@@ -240,7 +295,7 @@ def extract_answer_numbers(
 
     marker_matches = list(ANSWER_MARKER_RE.finditer(text))
     if marker_matches:
-        return extract_numbers(
+        return extract_number_candidates(
             strip_temporal_context(
                 text[marker_matches[-1].end() :],
                 answer_money_scale=answer_money_scale,
@@ -250,7 +305,7 @@ def extract_answer_numbers(
 
     calculation_matches = list(CALCULATION_RESULT_RE.finditer(text))
     if calculation_matches:
-        parsed = parse_number_token(
+        parsed = parse_number_candidate(
             calculation_matches[-1].group("value"),
             calculation_matches[-1].group("unit"),
             answer_money_scale=answer_money_scale,
@@ -258,11 +313,27 @@ def extract_answer_numbers(
         if parsed is not None:
             return [parsed]
 
-    numbers = extract_numbers(
+    candidates = extract_number_candidates(
         strip_temporal_context(text, answer_money_scale=answer_money_scale),
         answer_money_scale=answer_money_scale,
     )
-    return numbers if len(numbers) <= 1 else []
+    return candidates if len(candidates) <= 1 else []
+
+
+def extract_answer_numbers(
+    value: Any,
+    *,
+    answer_money_scale: str = "millions",
+) -> list[float]:
+    """Extract numbers that are likely to be the answer, not copied context."""
+
+    return [
+        candidate.value
+        for candidate in extract_answer_number_candidates(
+            value,
+            answer_money_scale=answer_money_scale,
+        )
+    ]
 
 
 def is_numeric_answer(value: Any) -> bool:
@@ -291,6 +362,30 @@ def numbers_match(
         rel_tol=relative_tolerance,
         abs_tol=absolute_tolerance,
     )
+
+
+def is_money_unit(unit: str | None) -> bool:
+    return bool(unit) and any(
+        marker in unit
+        for marker in ("usd", "dollar", "million", "billion")
+    )
+
+
+def has_compatible_unit(
+    expected: NumberCandidate,
+    observed: NumberCandidate,
+    *,
+    answer_expects_money: bool,
+) -> bool:
+    if not answer_expects_money:
+        return True
+
+    if observed.is_percent:
+        return False
+    if observed.unit and not is_money_unit(observed.unit):
+        return False
+
+    return True
 
 
 def rounded_billion_tolerance(
@@ -329,15 +424,16 @@ def deterministic_match(
         return normalize_text(gold_answer) == normalize_text(model_answer)
 
     answer_money_scale = infer_answer_money_scale(question)
+    answer_expects_money = expects_money_answer(question, gold_answer)
     effective_absolute_tolerance = max(
         absolute_tolerance,
         rounded_billion_tolerance(gold_answer, answer_money_scale) or 0.0,
     )
-    expected_numbers = extract_numbers(
+    expected_numbers = extract_number_candidates(
         gold_answer,
         answer_money_scale=answer_money_scale,
     )
-    observed_numbers = extract_answer_numbers(
+    observed_numbers = extract_answer_number_candidates(
         model_answer,
         answer_money_scale=answer_money_scale,
     )
@@ -348,10 +444,15 @@ def deterministic_match(
             for expected in expected_numbers
             for observed in observed_numbers
             if numbers_match(
-                expected,
-                observed,
+                expected.value,
+                observed.value,
                 relative_tolerance=relative_tolerance,
                 absolute_tolerance=effective_absolute_tolerance,
+            )
+            and has_compatible_unit(
+                expected,
+                observed,
+                answer_expects_money=answer_expects_money,
             )
         ]
         if not matched_pairs:
@@ -361,13 +462,13 @@ def deterministic_match(
             return any(
                 numbers_match(
                     0.0,
-                    expected,
+                    expected.value,
                     relative_tolerance=relative_tolerance,
                     absolute_tolerance=effective_absolute_tolerance,
                 )
                 and numbers_match(
                     0.0,
-                    observed,
+                    observed.value,
                     relative_tolerance=relative_tolerance,
                     absolute_tolerance=effective_absolute_tolerance,
                 )

--- a/scripts/evaluate_results.py
+++ b/scripts/evaluate_results.py
@@ -203,7 +203,7 @@ def extract_answer_numbers(
     marker_matches = list(ANSWER_MARKER_RE.finditer(text))
     if marker_matches:
         return extract_numbers(
-            text[marker_matches[-1].end() :],
+            CONTEXT_YEAR_RE.sub(" ", text[marker_matches[-1].end() :]),
             answer_money_scale=answer_money_scale,
         )[:1]
 

--- a/scripts/evaluate_results.py
+++ b/scripts/evaluate_results.py
@@ -26,6 +26,18 @@ NUMERIC_ANSWER_RE = re.compile(
     r"(?:\s*(?:usd|dollars?|millions?|billions?|shares?|bps|basis points))?$",
     re.IGNORECASE,
 )
+FILING_BLOCK_RE = re.compile(
+    r"\[START OF FILING\].*?\[END OF FILING\]",
+    re.IGNORECASE | re.DOTALL,
+)
+FILING_START_RE = re.compile(r"\[START OF FILING\].*$", re.IGNORECASE | re.DOTALL)
+FILING_END_RE = re.compile(r"^.*?\[END OF FILING\]", re.IGNORECASE | re.DOTALL)
+CONTEXT_YEAR_RE = re.compile(r"\b(?:FY|fiscal year)\s*\d{4}\b", re.IGNORECASE)
+ANSWER_MARKER_RE = re.compile(
+    r"(?:^|\n|\b)(?:final\s+(?:answer|result)|answer|result)\s*"
+    r"(?:is|was|were|would\s+be|:|=)\s*",
+    re.IGNORECASE | re.DOTALL,
+)
 REFUSAL_PHRASES = (
     "as an ai",
     "cannot provide",
@@ -93,6 +105,31 @@ def extract_numbers(value: Any) -> list[float]:
     return numbers
 
 
+def strip_filing_context(value: str) -> str:
+    text = FILING_BLOCK_RE.sub(" ", value)
+    text = FILING_START_RE.sub(" ", text)
+    text = FILING_END_RE.sub(" ", text)
+    return text.strip()
+
+
+def extract_answer_numbers(value: Any) -> list[float]:
+    """Extract numbers that are likely to be the answer, not copied context."""
+
+    if not isinstance(value, str):
+        return extract_numbers(value)
+
+    text = strip_filing_context(value)
+    if not text:
+        return []
+
+    marker_matches = list(ANSWER_MARKER_RE.finditer(text))
+    if marker_matches:
+        return extract_numbers(text[marker_matches[-1].end() :])[:1]
+
+    numbers = extract_numbers(CONTEXT_YEAR_RE.sub(" ", text))
+    return numbers if len(numbers) <= 1 else []
+
+
 def is_numeric_answer(value: Any) -> bool:
     if isinstance(value, bool):
         return False
@@ -130,7 +167,7 @@ def deterministic_match(
 ) -> bool:
     """Score a response without an LLM judge.
 
-    Numeric gold answers are matched against any number in the model answer.
+    Numeric gold answers are matched against the response's answer span.
     Non-numeric gold answers fall back to exact normalized string equality.
     This deliberately avoids claiming semantic equivalence for free-form text.
     """
@@ -142,7 +179,7 @@ def deterministic_match(
         return normalize_text(gold_answer) == normalize_text(model_answer)
 
     expected_numbers = extract_numbers(gold_answer)
-    observed_numbers = extract_numbers(model_answer)
+    observed_numbers = extract_answer_numbers(model_answer)
 
     if expected_numbers:
         return any(
@@ -182,10 +219,18 @@ def get_gold_answer(row: dict[str, Any]) -> Any:
 
 
 def get_model_answer(row: dict[str, Any]) -> Any:
-    for field in ("model_answer", "prediction", "predicted_answer", "response"):
+    for field in (
+        "final_answer",
+        "model_answer",
+        "prediction",
+        "predicted_answer",
+        "response",
+    ):
         if field in row:
             return row[field]
-    raise KeyError("missing model_answer, prediction, predicted_answer, or response")
+    raise KeyError(
+        "missing final_answer, model_answer, prediction, predicted_answer, or response"
+    )
 
 
 def summarize_file(

--- a/scripts/evaluate_results.py
+++ b/scripts/evaluate_results.py
@@ -49,8 +49,16 @@ REFUSAL_PHRASES = (
     "i don't have",
     "i do not have",
     "no information",
+    "no explicit mention",
+    "no explicit information",
     "not enough information",
     "not provided",
+    "does not explicitly mention",
+    "doesn't explicitly mention",
+    "does not explicitly outline",
+    "doesn't explicitly outline",
+    "does not explicitly state",
+    "doesn't explicitly state",
     "recommend checking",
     "unable to",
 )
@@ -77,12 +85,16 @@ def parse_number_token(token: str) -> float | None:
     text = token.strip()
     negative = text.startswith("(") and text.endswith(")")
     text = text.strip("()")
+    is_percent = "%" in text
     text = text.replace("$", "").replace(",", "").replace("%", "")
 
     try:
         value = float(text)
     except ValueError:
         return None
+
+    if is_percent:
+        value /= 100.0
 
     return -value if negative else value
 

--- a/scripts/evaluate_results.py
+++ b/scripts/evaluate_results.py
@@ -24,6 +24,10 @@ UNIT_PATTERN = (
     r"(?:usd(?:\s+(?:millions?|billions?))?|dollars?|millions?|billions?|"
     r"shares?|bps|basis points)"
 )
+MONEY_SCALE_RE = re.compile(
+    r"\b(?:usd\s+)?(?P<scale>millions?|billions?)\b",
+    re.IGNORECASE,
+)
 NUMBER_RE = re.compile(
     rf"(?<![A-Za-z_])(?P<number>\(?[-+]?\$?\d[\d,]*(?:\.\d+)?%?\)?)(?![A-Za-z_])"
     rf"(?:\s*(?P<unit>{UNIT_PATTERN}))?",
@@ -94,19 +98,44 @@ def normalize_text(value: Any) -> str:
     return " ".join(str(value).strip().lower().split())
 
 
-def magnitude_multiplier(unit: str | None) -> float:
-    """Return a multiplier that normalizes common money magnitudes to millions."""
+def infer_answer_money_scale(question: Any) -> str:
+    """Infer whether numeric gold answers are expressed in millions or billions."""
+
+    text = normalize_text(question)
+    matches = list(MONEY_SCALE_RE.finditer(text))
+    if not matches:
+        return "millions"
+
+    scale = matches[-1].group("scale")
+    if scale.lower().startswith("billion"):
+        return "billions"
+    return "millions"
+
+
+def magnitude_multiplier(
+    unit: str | None,
+    *,
+    answer_money_scale: str = "millions",
+) -> float:
+    """Return a multiplier that normalizes common money magnitudes to the answer scale."""
 
     if not unit:
         return 1.0
 
     normalized_unit = normalize_text(unit)
     if "billion" in normalized_unit:
-        return 1000.0
+        return 1.0 if answer_money_scale == "billions" else 1000.0
+    if "million" in normalized_unit:
+        return 0.001 if answer_money_scale == "billions" else 1.0
     return 1.0
 
 
-def parse_number_token(token: str, unit: str | None = None) -> float | None:
+def parse_number_token(
+    token: str,
+    unit: str | None = None,
+    *,
+    answer_money_scale: str = "millions",
+) -> float | None:
     """Parse a currency/percent/parenthesized number token into a float."""
 
     text = token.strip()
@@ -123,12 +152,12 @@ def parse_number_token(token: str, unit: str | None = None) -> float | None:
     if is_percent:
         value /= 100.0
 
-    value *= magnitude_multiplier(unit)
+    value *= magnitude_multiplier(unit, answer_money_scale=answer_money_scale)
 
     return -value if negative else value
 
 
-def extract_numbers(value: Any) -> list[float]:
+def extract_numbers(value: Any, *, answer_money_scale: str = "millions") -> list[float]:
     """Extract numeric tokens from strings or return numeric values directly."""
 
     if isinstance(value, bool):
@@ -140,7 +169,11 @@ def extract_numbers(value: Any) -> list[float]:
 
     numbers: list[float] = []
     for match in NUMBER_RE.finditer(str(value)):
-        parsed = parse_number_token(match.group("number"), match.group("unit"))
+        parsed = parse_number_token(
+            match.group("number"),
+            match.group("unit"),
+            answer_money_scale=answer_money_scale,
+        )
         if parsed is not None:
             numbers.append(parsed)
     return numbers
@@ -153,11 +186,15 @@ def strip_filing_context(value: str) -> str:
     return text.strip()
 
 
-def extract_answer_numbers(value: Any) -> list[float]:
+def extract_answer_numbers(
+    value: Any,
+    *,
+    answer_money_scale: str = "millions",
+) -> list[float]:
     """Extract numbers that are likely to be the answer, not copied context."""
 
     if not isinstance(value, str):
-        return extract_numbers(value)
+        return extract_numbers(value, answer_money_scale=answer_money_scale)
 
     text = strip_filing_context(value)
     if not text:
@@ -165,18 +202,25 @@ def extract_answer_numbers(value: Any) -> list[float]:
 
     marker_matches = list(ANSWER_MARKER_RE.finditer(text))
     if marker_matches:
-        return extract_numbers(text[marker_matches[-1].end() :])[:1]
+        return extract_numbers(
+            text[marker_matches[-1].end() :],
+            answer_money_scale=answer_money_scale,
+        )[:1]
 
     calculation_matches = list(CALCULATION_RESULT_RE.finditer(text))
     if calculation_matches:
         parsed = parse_number_token(
             calculation_matches[-1].group("value"),
             calculation_matches[-1].group("unit"),
+            answer_money_scale=answer_money_scale,
         )
         if parsed is not None:
             return [parsed]
 
-    numbers = extract_numbers(CONTEXT_YEAR_RE.sub(" ", text))
+    numbers = extract_numbers(
+        CONTEXT_YEAR_RE.sub(" ", text),
+        answer_money_scale=answer_money_scale,
+    )
     return numbers if len(numbers) <= 1 else []
 
 
@@ -208,12 +252,28 @@ def numbers_match(
     )
 
 
+def rounded_billion_tolerance(
+    gold_answer: Any,
+    answer_money_scale: str,
+) -> float | None:
+    if answer_money_scale != "billions":
+        return None
+
+    text = str(gold_answer).strip()
+    match = re.search(r"[-+]?\d+\.(?P<decimals>\d+)", text)
+    if not match:
+        return None
+
+    return 0.5 * 10 ** (-len(match.group("decimals")))
+
+
 def deterministic_match(
     gold_answer: Any,
     model_answer: Any,
     *,
     relative_tolerance: float,
     absolute_tolerance: float,
+    question: Any = None,
 ) -> bool:
     """Score a response without an LLM judge.
 
@@ -227,8 +287,19 @@ def deterministic_match(
             return False
         return normalize_text(gold_answer) == normalize_text(model_answer)
 
-    expected_numbers = extract_numbers(gold_answer)
-    observed_numbers = extract_answer_numbers(model_answer)
+    answer_money_scale = infer_answer_money_scale(question)
+    effective_absolute_tolerance = max(
+        absolute_tolerance,
+        rounded_billion_tolerance(gold_answer, answer_money_scale) or 0.0,
+    )
+    expected_numbers = extract_numbers(
+        gold_answer,
+        answer_money_scale=answer_money_scale,
+    )
+    observed_numbers = extract_answer_numbers(
+        model_answer,
+        answer_money_scale=answer_money_scale,
+    )
 
     if expected_numbers:
         matched_pairs = [
@@ -239,7 +310,7 @@ def deterministic_match(
                 expected,
                 observed,
                 relative_tolerance=relative_tolerance,
-                absolute_tolerance=absolute_tolerance,
+                absolute_tolerance=effective_absolute_tolerance,
             )
         ]
         if not matched_pairs:
@@ -251,13 +322,13 @@ def deterministic_match(
                     0.0,
                     expected,
                     relative_tolerance=relative_tolerance,
-                    absolute_tolerance=absolute_tolerance,
+                    absolute_tolerance=effective_absolute_tolerance,
                 )
                 and numbers_match(
                     0.0,
                     observed,
                     relative_tolerance=relative_tolerance,
-                    absolute_tolerance=absolute_tolerance,
+                    absolute_tolerance=effective_absolute_tolerance,
                 )
                 for expected, observed in matched_pairs
             )
@@ -333,6 +404,7 @@ def summarize_file(
             model_answer,
             relative_tolerance=relative_tolerance,
             absolute_tolerance=absolute_tolerance,
+            question=row.get("question"),
         ):
             deterministic_matches += 1
 

--- a/scripts/evaluate_results.py
+++ b/scripts/evaluate_results.py
@@ -65,8 +65,8 @@ ANSWER_MARKER_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 CALCULATION_RESULT_RE = re.compile(
-    r"[^=\n]*(?:[/+*]|\s-\s)[^=\n]*=\s*"
-    r"(?P<value>\(?[-+]?\$?\d[\d,]*(?:\.\d+)?%?\)?)"
+    r"[^=\n]*(?:[/+*]|\s-\s)[^=\n]*(?:\n\s*)?=\s*"
+    r"(?P<value>\(?[-+]?\$?\d[\d,]*(?:\.\d+)?%?\)?)(?!,\d)"
     rf"(?:\s*(?P<unit>{UNIT_PATTERN}))?"
     r"(?=\s*(?:[.,;:]|\n|$))",
     re.IGNORECASE,

--- a/scripts/evaluate_results.py
+++ b/scripts/evaluate_results.py
@@ -46,6 +46,19 @@ FILING_START_RE = re.compile(r"\[START OF FILING\].*$", re.IGNORECASE | re.DOTAL
 FILING_END_RE = re.compile(r"^.*?\[END OF FILING\]", re.IGNORECASE | re.DOTALL)
 CONTEXT_YEAR_RE = re.compile(r"\b(?:FY|fiscal year)\s*\d{2,4}\b", re.IGNORECASE)
 BARE_YEAR_RE = re.compile(r"\b(?:19|20)\d{2}\b")
+MONTH_NAME_PATTERN = (
+    r"(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|"
+    r"jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|"
+    r"nov(?:ember)?|dec(?:ember)?)"
+)
+CONTEXT_DATE_RE = re.compile(
+    rf"\b{MONTH_NAME_PATTERN}\.?\s+\d{{1,2}}(?:st|nd|rd|th)?[,]?\s+"
+    r"(?:19|20)\d{2}\b"
+    rf"|\b\d{{1,2}}(?:st|nd|rd|th)?\s+{MONTH_NAME_PATTERN}\.?,?\s+"
+    r"(?:19|20)\d{2}\b"
+    r"|\b\d{1,2}[/-]\d{1,2}[/-](?:\d{2}|\d{4})\b",
+    re.IGNORECASE,
+)
 ANSWER_MARKER_RE = re.compile(
     r"(?:^|\n|\b)(?:final\s+(?:answer|result)|answer|result)\s*"
     r"(?:is|was|were|would\s+be|:|=)\s*",
@@ -187,14 +200,19 @@ def strip_filing_context(value: str) -> str:
     return text.strip()
 
 
-def strip_context_years(
+def strip_temporal_context(
     value: str,
     *,
     answer_money_scale: str = "millions",
 ) -> str:
-    """Remove fiscal-year context when another numeric answer candidate remains."""
+    """Remove date/year context when another numeric answer candidate remains."""
 
-    text = CONTEXT_YEAR_RE.sub(" ", value)
+    text = value
+    without_full_dates = CONTEXT_DATE_RE.sub(" ", text)
+    if extract_numbers(without_full_dates, answer_money_scale=answer_money_scale):
+        text = without_full_dates
+
+    text = CONTEXT_YEAR_RE.sub(" ", text)
     numbers = extract_numbers(text, answer_money_scale=answer_money_scale)
     if len(numbers) <= 1:
         return text
@@ -223,7 +241,7 @@ def extract_answer_numbers(
     marker_matches = list(ANSWER_MARKER_RE.finditer(text))
     if marker_matches:
         return extract_numbers(
-            strip_context_years(
+            strip_temporal_context(
                 text[marker_matches[-1].end() :],
                 answer_money_scale=answer_money_scale,
             ),
@@ -241,7 +259,7 @@ def extract_answer_numbers(
             return [parsed]
 
     numbers = extract_numbers(
-        strip_context_years(text, answer_money_scale=answer_money_scale),
+        strip_temporal_context(text, answer_money_scale=answer_money_scale),
         answer_money_scale=answer_money_scale,
     )
     return numbers if len(numbers) <= 1 else []

--- a/scripts/evaluate_results.py
+++ b/scripts/evaluate_results.py
@@ -44,7 +44,8 @@ FILING_BLOCK_RE = re.compile(
 )
 FILING_START_RE = re.compile(r"\[START OF FILING\].*$", re.IGNORECASE | re.DOTALL)
 FILING_END_RE = re.compile(r"^.*?\[END OF FILING\]", re.IGNORECASE | re.DOTALL)
-CONTEXT_YEAR_RE = re.compile(r"\b(?:FY|fiscal year)\s*\d{4}\b", re.IGNORECASE)
+CONTEXT_YEAR_RE = re.compile(r"\b(?:FY|fiscal year)\s*\d{2,4}\b", re.IGNORECASE)
+BARE_YEAR_RE = re.compile(r"\b(?:19|20)\d{2}\b")
 ANSWER_MARKER_RE = re.compile(
     r"(?:^|\n|\b)(?:final\s+(?:answer|result)|answer|result)\s*"
     r"(?:is|was|were|would\s+be|:|=)\s*",
@@ -186,6 +187,25 @@ def strip_filing_context(value: str) -> str:
     return text.strip()
 
 
+def strip_context_years(
+    value: str,
+    *,
+    answer_money_scale: str = "millions",
+) -> str:
+    """Remove fiscal-year context when another numeric answer candidate remains."""
+
+    text = CONTEXT_YEAR_RE.sub(" ", value)
+    numbers = extract_numbers(text, answer_money_scale=answer_money_scale)
+    if len(numbers) <= 1:
+        return text
+
+    without_bare_years = BARE_YEAR_RE.sub(" ", text)
+    if extract_numbers(without_bare_years, answer_money_scale=answer_money_scale):
+        return without_bare_years
+
+    return text
+
+
 def extract_answer_numbers(
     value: Any,
     *,
@@ -203,7 +223,10 @@ def extract_answer_numbers(
     marker_matches = list(ANSWER_MARKER_RE.finditer(text))
     if marker_matches:
         return extract_numbers(
-            CONTEXT_YEAR_RE.sub(" ", text[marker_matches[-1].end() :]),
+            strip_context_years(
+                text[marker_matches[-1].end() :],
+                answer_money_scale=answer_money_scale,
+            ),
             answer_money_scale=answer_money_scale,
         )[:1]
 
@@ -218,7 +241,7 @@ def extract_answer_numbers(
             return [parsed]
 
     numbers = extract_numbers(
-        CONTEXT_YEAR_RE.sub(" ", text),
+        strip_context_years(text, answer_money_scale=answer_money_scale),
         answer_money_scale=answer_money_scale,
     )
     return numbers if len(numbers) <= 1 else []

--- a/scripts/test_evaluate_results.py
+++ b/scripts/test_evaluate_results.py
@@ -24,6 +24,27 @@ class EvaluateResultsTest(unittest.TestCase):
             )
         )
 
+    def test_numeric_answer_normalizes_billion_unit_to_millions(self):
+        self.assertTrue(
+            deterministic_match(
+                5818,
+                (
+                    "Lockheed Martin's FY2021 net working capital was "
+                    "$19.815 billion - $13.997 billion = $5.818 billion."
+                ),
+                relative_tolerance=0.001,
+                absolute_tolerance=1e-6,
+            )
+        )
+        self.assertFalse(
+            deterministic_match(
+                5818,
+                "Final answer: $5,818 billion.",
+                relative_tolerance=0.001,
+                absolute_tolerance=1e-6,
+            )
+        )
+
     def test_numeric_answer_ignores_alphanumeric_identifiers(self):
         self.assertTrue(
             deterministic_match(

--- a/scripts/test_evaluate_results.py
+++ b/scripts/test_evaluate_results.py
@@ -19,6 +19,47 @@ class EvaluateResultsTest(unittest.TestCase):
             )
         )
 
+    def test_numeric_answer_does_not_match_copied_filing_context(self):
+        self.assertFalse(
+            deterministic_match(
+                59268,
+                "[START OF FILING]\nTOTAL ASSETS\n$59,268\n[END OF FILING]",
+                relative_tolerance=0.01,
+                absolute_tolerance=1e-6,
+            )
+        )
+
+    def test_numeric_answer_uses_explicit_answer_span(self):
+        self.assertFalse(
+            deterministic_match(
+                59268,
+                (
+                    "[START OF FILING]\nTOTAL ASSETS\n$59,268\n[END OF FILING]\n"
+                    "Final answer: $55,556"
+                ),
+                relative_tolerance=0.01,
+                absolute_tolerance=1e-6,
+            )
+        )
+        self.assertTrue(
+            deterministic_match(
+                59268,
+                "The filing lists $55,556 for 2020. Final answer: $59,268",
+                relative_tolerance=0.01,
+                absolute_tolerance=1e-6,
+            )
+        )
+
+    def test_numeric_answer_requires_unambiguous_span(self):
+        self.assertFalse(
+            deterministic_match(
+                59268,
+                "The filing lists $59,268 in 2021 and $55,556 in 2020.",
+                relative_tolerance=0.01,
+                absolute_tolerance=1e-6,
+            )
+        )
+
     def test_refusal_does_not_match_even_when_it_mentions_numbers(self):
         self.assertFalse(
             deterministic_match(

--- a/scripts/test_evaluate_results.py
+++ b/scripts/test_evaluate_results.py
@@ -198,6 +198,23 @@ class EvaluateResultsTest(unittest.TestCase):
             )
         )
 
+    def test_numeric_answer_uses_multiline_final_calculation_span(self):
+        self.assertTrue(
+            deterministic_match(
+                24.26,
+                (
+                    "Average = ($282 million + $253 million) / 2 = $267.5 million.\n\n"
+                    "Fixed Asset Turnover Ratio = Revenue / Average PP&E \n"
+                    "           = $6,489 million / $267.5 million\n"
+                    "           = 24.26\n\n"
+                    "Rounding to two decimal places, the FY2019 fixed asset "
+                    "turnover ratio for Activision Blizzard is 24.26."
+                ),
+                relative_tolerance=0.001,
+                absolute_tolerance=1e-6,
+            )
+        )
+
     def test_numeric_answer_requires_unambiguous_span(self):
         self.assertFalse(
             deterministic_match(

--- a/scripts/test_evaluate_results.py
+++ b/scripts/test_evaluate_results.py
@@ -1,0 +1,50 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from evaluate_results import deterministic_match, is_numeric_answer, looks_like_refusal
+
+
+class EvaluateResultsTest(unittest.TestCase):
+    def test_numeric_answer_matches_number_in_model_answer(self):
+        self.assertTrue(
+            deterministic_match(
+                "$1,577.00",
+                "The FY2018 capital expenditure amount was $1,577 million.",
+                relative_tolerance=0.01,
+                absolute_tolerance=1e-6,
+            )
+        )
+
+    def test_refusal_does_not_match_even_when_it_mentions_numbers(self):
+        self.assertFalse(
+            deterministic_match(
+                "$1,577.00",
+                "As an AI, I don't have access to the 2018 filing.",
+                relative_tolerance=0.01,
+                absolute_tolerance=1e-6,
+            )
+        )
+
+    def test_explanatory_answer_is_not_treated_as_numeric_only(self):
+        answer = "Operating margin decreased by 1.7% due to one-off charges."
+        self.assertFalse(is_numeric_answer(answer))
+        self.assertFalse(
+            deterministic_match(
+                answer,
+                "Operating margin changed in FY2022.",
+                relative_tolerance=0.01,
+                absolute_tolerance=1e-6,
+            )
+        )
+
+    def test_refusal_detector_is_phrase_based(self):
+        self.assertTrue(looks_like_refusal("I do not have access to that filing."))
+        self.assertFalse(looks_like_refusal("No, revenue did not increase."))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_evaluate_results.py
+++ b/scripts/test_evaluate_results.py
@@ -236,6 +236,39 @@ class EvaluateResultsTest(unittest.TestCase):
             )
         )
 
+    def test_money_answer_rejects_percentage_observed_value(self):
+        question = (
+            "How much (in USD billions) did American Water Works pay out "
+            "in cash dividends for FY2020?"
+        )
+        self.assertFalse(
+            deterministic_match(
+                0.4,
+                "Approximately 40% of the regulatory liability balance was collected.",
+                relative_tolerance=0.001,
+                absolute_tolerance=1e-6,
+                question=question,
+            )
+        )
+        self.assertTrue(
+            deterministic_match(
+                0.4,
+                "Final answer: $0.4 billion.",
+                relative_tolerance=0.001,
+                absolute_tolerance=1e-6,
+                question=question,
+            )
+        )
+        self.assertTrue(
+            deterministic_match(
+                0.4,
+                "Final answer: 0.4.",
+                relative_tolerance=0.001,
+                absolute_tolerance=1e-6,
+                question=question,
+            )
+        )
+
     def test_default_tolerance_rejects_distinct_rounded_percentages(self):
         args = parse_args(["results.jsonl"])
 

--- a/scripts/test_evaluate_results.py
+++ b/scripts/test_evaluate_results.py
@@ -140,6 +140,35 @@ class EvaluateResultsTest(unittest.TestCase):
             )
         )
 
+    def test_numeric_answer_ignores_bare_context_years_when_value_remains(self):
+        self.assertTrue(
+            deterministic_match(
+                1577,
+                (
+                    "According to the provided information, the amount for "
+                    "2018 is $1,577 million USD."
+                ),
+                relative_tolerance=0.001,
+                absolute_tolerance=1e-6,
+            )
+        )
+        self.assertTrue(
+            deterministic_match(
+                1577,
+                "Final answer: for 2018, the amount is $1,577 million.",
+                relative_tolerance=0.001,
+                absolute_tolerance=1e-6,
+            )
+        )
+        self.assertTrue(
+            deterministic_match(
+                2018,
+                "Final answer: 2018",
+                relative_tolerance=0.001,
+                absolute_tolerance=1e-6,
+            )
+        )
+
     def test_numeric_answer_uses_final_calculation_span_without_marker(self):
         self.assertTrue(
             deterministic_match(

--- a/scripts/test_evaluate_results.py
+++ b/scripts/test_evaluate_results.py
@@ -127,6 +127,19 @@ class EvaluateResultsTest(unittest.TestCase):
             )
         )
 
+    def test_numeric_answer_ignores_context_years_in_explicit_answer_span(self):
+        self.assertTrue(
+            deterministic_match(
+                12645,
+                (
+                    "Therefore, the answer is that Boeing's net property, plant "
+                    "and equipment at the end of FY2018 was $12,645 million."
+                ),
+                relative_tolerance=0.001,
+                absolute_tolerance=1e-6,
+            )
+        )
+
     def test_numeric_answer_uses_final_calculation_span_without_marker(self):
         self.assertTrue(
             deterministic_match(

--- a/scripts/test_evaluate_results.py
+++ b/scripts/test_evaluate_results.py
@@ -133,13 +133,23 @@ class EvaluateResultsTest(unittest.TestCase):
             )
         )
 
-    def test_no_evidence_answer_is_treated_as_refusal(self):
+    def test_no_evidence_zero_answer_can_match_explicit_zero_gold(self):
         answer = "There is no explicit mention of this in the filing. Final answer: 0"
         self.assertTrue(looks_like_refusal(answer))
-        self.assertFalse(
+        self.assertTrue(
             deterministic_match(
                 0,
                 answer,
+                relative_tolerance=0.01,
+                absolute_tolerance=1e-6,
+            )
+        )
+
+    def test_no_evidence_refusal_does_not_override_nonzero_gold(self):
+        self.assertFalse(
+            deterministic_match(
+                1577,
+                "There is no explicit mention of this in the filing. Final answer: 0",
                 relative_tolerance=0.01,
                 absolute_tolerance=1e-6,
             )

--- a/scripts/test_evaluate_results.py
+++ b/scripts/test_evaluate_results.py
@@ -19,6 +19,16 @@ class EvaluateResultsTest(unittest.TestCase):
             )
         )
 
+    def test_numeric_answer_ignores_alphanumeric_identifiers(self):
+        self.assertTrue(
+            deterministic_match(
+                1577,
+                "For Q2 of FY2023, the capital expenditure amount for 3M is $1,577 million.",
+                relative_tolerance=0.01,
+                absolute_tolerance=1e-6,
+            )
+        )
+
     def test_numeric_answer_does_not_match_copied_filing_context(self):
         self.assertFalse(
             deterministic_match(

--- a/scripts/test_evaluate_results.py
+++ b/scripts/test_evaluate_results.py
@@ -65,6 +65,23 @@ class EvaluateResultsTest(unittest.TestCase):
             )
         )
 
+    def test_numeric_answer_uses_final_calculation_span_without_marker(self):
+        self.assertTrue(
+            deterministic_match(
+                24.26,
+                (
+                    "The FY2019 revenue for Activision Blizzard is $6,489 million. "
+                    "The Property, Plant, and Equipment (PP&E) for FY2018 is "
+                    "$282 million and for FY2019 is $253 million. The average PP&E "
+                    "between FY2018 and FY2019 is ($282 million + $253 million) / "
+                    "2 = $267.5 million.\n\nTherefore, the fixed asset turnover "
+                    "ratio for FY2019 is $6,489 million / $267.5 million = 24.26."
+                ),
+                relative_tolerance=0.001,
+                absolute_tolerance=1e-6,
+            )
+        )
+
     def test_numeric_answer_requires_unambiguous_span(self):
         self.assertFalse(
             deterministic_match(

--- a/scripts/test_evaluate_results.py
+++ b/scripts/test_evaluate_results.py
@@ -45,6 +45,47 @@ class EvaluateResultsTest(unittest.TestCase):
             )
         )
 
+    def test_numeric_answer_preserves_billion_question_scale(self):
+        self.assertTrue(
+            deterministic_match(
+                8.7,
+                (
+                    "The year end FY2018 net PP&E (Property, Plant, and "
+                    "Equipment) for 3M is $8.738 billion."
+                ),
+                relative_tolerance=0.001,
+                absolute_tolerance=1e-6,
+                question=(
+                    "What is the year end FY2018 net PPNE for 3M? "
+                    "Answer in USD billions."
+                ),
+            )
+        )
+        self.assertTrue(
+            deterministic_match(
+                4.6,
+                "The FY2021 capital expenditure amount for PepsiCo is $4.625 billion.",
+                relative_tolerance=0.001,
+                absolute_tolerance=1e-6,
+                question=(
+                    "What is the FY2021 capital expenditure amount "
+                    "(in USD billions) for PepsiCo?"
+                ),
+            )
+        )
+        self.assertTrue(
+            deterministic_match(
+                4.6,
+                "The FY2021 capital expenditure amount for PepsiCo is $4,625 million.",
+                relative_tolerance=0.001,
+                absolute_tolerance=1e-6,
+                question=(
+                    "What is the FY2021 capital expenditure amount "
+                    "(in USD billions) for PepsiCo?"
+                ),
+            )
+        )
+
     def test_numeric_answer_ignores_alphanumeric_identifiers(self):
         self.assertTrue(
             deterministic_match(

--- a/scripts/test_evaluate_results.py
+++ b/scripts/test_evaluate_results.py
@@ -70,6 +70,36 @@ class EvaluateResultsTest(unittest.TestCase):
             )
         )
 
+    def test_percent_answer_preserves_percent_scale(self):
+        self.assertTrue(
+            deterministic_match(
+                1.015,
+                "The final answer is 101.4%.",
+                relative_tolerance=0.01,
+                absolute_tolerance=1e-6,
+            )
+        )
+        self.assertFalse(
+            deterministic_match(
+                1.015,
+                "The final answer is 1.014%.",
+                relative_tolerance=0.01,
+                absolute_tolerance=1e-6,
+            )
+        )
+
+    def test_no_evidence_answer_is_treated_as_refusal(self):
+        answer = "There is no explicit mention of this in the filing. Final answer: 0"
+        self.assertTrue(looks_like_refusal(answer))
+        self.assertFalse(
+            deterministic_match(
+                0,
+                answer,
+                relative_tolerance=0.01,
+                absolute_tolerance=1e-6,
+            )
+        )
+
     def test_explanatory_answer_is_not_treated_as_numeric_only(self):
         answer = "Operating margin decreased by 1.7% due to one-off charges."
         self.assertFalse(is_numeric_answer(answer))

--- a/scripts/test_evaluate_results.py
+++ b/scripts/test_evaluate_results.py
@@ -154,6 +154,18 @@ class EvaluateResultsTest(unittest.TestCase):
         )
         self.assertTrue(
             deterministic_match(
+                11588,
+                (
+                    "Amazon's FY2019 net income attributable to shareholders "
+                    "is $11,588 million. This figure is listed for the year "
+                    "ended December 31, 2019."
+                ),
+                relative_tolerance=0.001,
+                absolute_tolerance=1e-6,
+            )
+        )
+        self.assertTrue(
+            deterministic_match(
                 1577,
                 "Final answer: for 2018, the amount is $1,577 million.",
                 relative_tolerance=0.001,

--- a/scripts/test_evaluate_results.py
+++ b/scripts/test_evaluate_results.py
@@ -5,7 +5,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
-from evaluate_results import deterministic_match, is_numeric_answer, looks_like_refusal
+from evaluate_results import (
+    deterministic_match,
+    is_numeric_answer,
+    looks_like_refusal,
+    parse_args,
+)
 
 
 class EvaluateResultsTest(unittest.TestCase):
@@ -95,6 +100,19 @@ class EvaluateResultsTest(unittest.TestCase):
                 "The final answer is 1.014%.",
                 relative_tolerance=0.01,
                 absolute_tolerance=1e-6,
+            )
+        )
+
+    def test_default_tolerance_rejects_distinct_rounded_percentages(self):
+        args = parse_args(["results.jsonl"])
+
+        self.assertEqual(args.relative_tolerance, 0.001)
+        self.assertFalse(
+            deterministic_match(
+                0.654,
+                "The final answer is 65.2%.",
+                relative_tolerance=args.relative_tolerance,
+                absolute_tolerance=args.absolute_tolerance,
             )
         )
 


### PR DESCRIPTION
## Summary
- add a dependency-free `scripts/evaluate_results.py` CLI for FinanceBench JSONL result files
- summarize the existing human labels and report a conservative deterministic match rate
- document the evaluator in the README and add stdlib unit tests for numeric matching, refusal handling, and text answers

## Why
This gives users a lightweight evaluation harness for the open-source sample and future prediction files without requiring an LLM judge or extra packages. It is a narrow first step related to #17: numeric gold answers can be checked deterministically, while free-form answers remain exact-match only so the script does not overstate semantic correctness.

## Validation
- `python -m py_compile scripts/evaluate_results.py scripts/test_evaluate_results.py`
- `python -m unittest scripts/test_evaluate_results.py`
- `python scripts/evaluate_results.py results/gpt-4_closedBook.jsonl`
- `python scripts/evaluate_results.py results/*.jsonl --format json`